### PR TITLE
Various fixes

### DIFF
--- a/bin/_deploy
+++ b/bin/_deploy
@@ -6,6 +6,7 @@ CLOUDFORMATION_BUCKET=$(cat .bucket-name-$STAGE_ENV)
 ./bin/build
 
 sam package \
+  --profile wustl \
   --region ${AWS_DEFAULT_REGION} \
   --template-file ./.aws-sam/build/template.yaml \
   --output-template-file ./.aws-sam/build/packaged.yaml \
@@ -13,6 +14,7 @@ sam package \
   --s3-prefix "space-stone-${STAGE_ENV}"
 
 sam deploy \
+  --profile wustl \
   --region ${AWS_DEFAULT_REGION} \
   --template-file ./.aws-sam/build/packaged.yaml \
   --stack-name "space-stone-${STAGE_ENV}" \

--- a/bin/build
+++ b/bin/build
@@ -9,7 +9,7 @@ rm -rf ./.aws-sam \
        ./vendor/bundle
 
 # Build SAM
-sam build
+sam build --profile wustl --region us-east-2
 pushd ./.aws-sam/build/SpaceStoneLambdaDownload/
 
 # Clean un-needed artifacts.

--- a/bin/build
+++ b/bin/build
@@ -22,6 +22,7 @@ rm -rf \
   README.md \
   test \
   tmp \
+  .ruby-lsp \
   vendor/bundle/ruby/3.*/cache
 find . -iname "*~undo-tree~" -delete
 popd
@@ -37,6 +38,23 @@ rm -rf \
    README.md \
    test \
    tmp \
+  .ruby-lsp \
+   vendor/bundle/ruby/3.*/cache
+find . -iname "*~undo-tree~" -delete
+popd
+
+pushd ./.aws-sam/build/SpaceStoneLambdaThumbnail/
+# Clean un-needed artifacts.
+rm -rf \
+   .env.development \
+   .env.test \
+   docker-compose.yml \
+   layers \
+   Dockerfile \
+   README.md \
+   test \
+   tmp \
+  .ruby-lsp \
    vendor/bundle/ruby/3.*/cache
 find . -iname "*~undo-tree~" -delete
 popd

--- a/bin/build
+++ b/bin/build
@@ -9,7 +9,7 @@ rm -rf ./.aws-sam \
        ./vendor/bundle
 
 # Build SAM
-sam build --profile wustl --region us-east-2
+sam build --profile wustl --region ${AWS_DEFAULT_REGION}
 pushd ./.aws-sam/build/SpaceStoneLambdaDownload/
 
 # Clean un-needed artifacts.

--- a/lib/space_stone.rb
+++ b/lib/space_stone.rb
@@ -66,6 +66,7 @@ def process_ia_id(ia_id)
   downloads.each do |path|
     SpaceStone::S3Service.upload(path)
     SpaceStone::SqsService.add(message: path.sub('/tmp/', ''), queue: 'ocr') if path.match(/jp2$/)
+    SpaceStone::SqsService.add(message: path.sub('/tmp/', ''), queue: 'thumbnail') if path.match(/jp2$/)
   end
 end
 

--- a/spec/space_stone/thumbnail_service_spec.rb
+++ b/spec/space_stone/thumbnail_service_spec.rb
@@ -12,16 +12,16 @@ describe SpaceStone::ThumbnailService do
   end
 
   after do
-    File.delete(thumbnail_location) if File.exists?(thumbnail_location)
+    File.delete(thumbnail_location) if File.exist?(thumbnail_location)
   end
 
   describe '#derive' do
     it 'derives a thumbnail from a path' do
-      expect(File.exists?(thumbnail_location)).to eq(false)
+      expect(File.exist?(thumbnail_location)).to eq(false)
 
       thumbnail_service.derive
 
-      expect(File.exists?(thumbnail_location)).to eq(true)
+      expect(File.exist?(thumbnail_location)).to eq(true)
     end
   end
 end

--- a/template.yaml
+++ b/template.yaml
@@ -20,6 +20,9 @@ Resources:
     Properties:
       CodeUri: .
       Handler: lib/space_stone.download
+      # TODO: Split gems into separate layer; other libs not necessary for download step
+      Layers:
+        - !Ref ProcessDocumentLayer
       Runtime: ruby3.2
       Timeout: 900
       MemorySize: 512


### PR DESCRIPTION
## ensure all lambdas are small enough to deploy

076edc37b3d52a68ed6871b860d717030e6656af


## fix gems not being found during download step

3c7c4aab5e11c055a7ad2291eb13e9e5e8c6e18c

Fixes this error that was being thrown while the download lambda was
running, causing it to fail:

`cannot load such file -- nokogiri`

## update spec to be compatible with Ruby 3.x

e23720d0ed9522de5aa1ae6b57c54f4ffb8c71dd


## add thumbnail derivation to process chain

b33f85291f7373093c51d833f5b7df899f8ed9a0

Before this change, SpaceStone only downloaded files to S3 and performed
OCR on them. The logic to derive thumbnails has already been added, but
it wasn't hooked into the primary process chain, so deriving thumbnails
had to be triggered manually separate from the primary process chain

## commit updated ProcessDocumentLayer.zip

270628fd6c3cc038a0110c1df2160a267686fa1b

This should have been included in this previous PR that updated Ruby:
- https://github.com/scientist-softserv/space_stone/pull/5

## stream zip to disk instead of holding in memory

a87d49a258b669c8d84f0747f26f7667bae64d9e

Large files would exceed the memory limit of the Lambda, causing it to
crash

## specify wustl profile in aws sam commands

32b35db12f0448c3d6b1a1188f765318a6d49914

