### PR TITLE
add ability to specify the path files are downloaded to

### DIFF
--- a/lib/space_stone.rb
+++ b/lib/space_stone.rb
@@ -65,7 +65,7 @@ def process_ia_id(ia_id, download_dir)
   downloads = ia_download.download_jp2s
   downloads += ia_download.dataset_files
   downloads.each do |path|
-    SpaceStone::S3Service.upload(path)
+    SpaceStone::S3Service.upload(path, download_dir)
     SpaceStone::SqsService.add(message: path.sub("#{download_dir}/", ''), queue: 'ocr') if path.match(/jp2$/)
     SpaceStone::SqsService.add(message: path.sub("#{download_dir}/", ''), queue: 'thumbnail') if path.match(/jp2$/)
   end

--- a/lib/space_stone.rb
+++ b/lib/space_stone.rb
@@ -10,15 +10,16 @@ require_relative './space_stone/s3_service'
 require_relative './space_stone/sqs_service'
 
 # Invokers
-def download(event:, context:) # rubocop:disable Lint/UnusedMethodArgument
+# :download_dir must be a full path (i.e. starts with "/") and have no trailing slash
+def download(event:, context:, download_dir: '/tmp') # rubocop:disable Lint/UnusedMethodArgument
   puts "event: #{event.inspect}" unless SpaceStone::Env.test?
   ia_ids = get_event_body(event: event)
   results = {}
 
   ia_ids.each do |ia_id|
-    jp2s = process_ia_id(ia_id.strip)
-    results[ia_id] = jp2s.map { |v| v.sub('/tmp/', '') }
-    puts %x{rm -rf /tmp/#{ia_id}}
+    jp2s = process_ia_id(ia_id.strip, download_dir)
+    results[ia_id] = jp2s.map { |v| v.sub("#{download_dir}/", '') }
+    puts %x{rm -rf #{download_dir}/#{ia_id}}
   end
   send_results(results)
 end
@@ -57,16 +58,16 @@ def thumbnail(event:, context:)
 end
 
 # Helpers
-def process_ia_id(ia_id)
-  FileUtils.mkdir_p("/tmp/#{ia_id}")
+def process_ia_id(ia_id, download_dir)
+  FileUtils.mkdir_p("#{download_dir}/#{ia_id}")
   # download zip file
-  ia_download = SpaceStone::IaDownload.new(id: ia_id)
+  ia_download = SpaceStone::IaDownload.new(id: ia_id, base_path: download_dir)
   downloads = ia_download.download_jp2s
   downloads += ia_download.dataset_files
   downloads.each do |path|
     SpaceStone::S3Service.upload(path)
-    SpaceStone::SqsService.add(message: path.sub('/tmp/', ''), queue: 'ocr') if path.match(/jp2$/)
-    SpaceStone::SqsService.add(message: path.sub('/tmp/', ''), queue: 'thumbnail') if path.match(/jp2$/)
+    SpaceStone::SqsService.add(message: path.sub("#{download_dir}/", ''), queue: 'ocr') if path.match(/jp2$/)
+    SpaceStone::SqsService.add(message: path.sub("#{download_dir}/", ''), queue: 'thumbnail') if path.match(/jp2$/)
   end
 end
 

--- a/lib/space_stone/ia_download.rb
+++ b/lib/space_stone/ia_download.rb
@@ -8,7 +8,7 @@ require 'zip'
 module SpaceStone
   # Download files from Internet Archive
   class IaDownload
-    attr_accessor :id
+    attr_accessor :id, :downloads_path
 
     def self.json_data
       return @json_data if @json_data
@@ -31,8 +31,11 @@ module SpaceStone
       @login_cookies = cookie_hash.to_cookie_string
     end
 
-    def initialize(id:)
+    # :base_path must be a full path (i.e. starts with "/") and have no trailing slash
+    def initialize(id:, base_path: '/tmp')
       @id = id
+      @downloads_path = "#{base_path}/#{id}/downloads"
+      FileUtils.mkdir_p @downloads_path
     end
 
     def login_cookies
@@ -51,14 +54,6 @@ module SpaceStone
       return '' unless jp2_zip_link
 
       @remote_file_link = url + jp2_zip_link
-    end
-
-    def downloads_path
-      return @downloads_path if @downloads_path
-
-      @downloads_path = "/tmp/#{id}/downloads"
-      FileUtils.mkdir_p @downloads_path
-      @downloads_path
     end
 
     def zip

--- a/lib/space_stone/s3_service.rb
+++ b/lib/space_stone/s3_service.rb
@@ -17,8 +17,8 @@ module SpaceStone
       @bucket ||= resource.bucket(ENV.fetch('AWS_S3_BUCKET'))
     end
 
-    def upload(path)
-      obj = bucket.object(path.sub('/tmp/', ''))
+    def upload(path, download_dir = '/tmp')
+      obj = bucket.object(path.sub("#{download_dir}/", ''))
       puts "upload path #{path} - #{File.exist?(path)}"
       obj.upload_file(path)
     end


### PR DESCRIPTION
This is setting up for a future PR that will include a script that we want to run on a server where the files should download to somewhere other than `/tmp`