### PR TITLE
IA to S3 migrator script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 !.env.development
 !.env.test
 *~undo-tree~
+tmp
+log

--- a/bin/build
+++ b/bin/build
@@ -23,6 +23,7 @@ rm -rf \
   test \
   tmp \
   .ruby-lsp \
+  log \
   vendor/bundle/ruby/3.*/cache
 find . -iname "*~undo-tree~" -delete
 popd
@@ -38,7 +39,8 @@ rm -rf \
    README.md \
    test \
    tmp \
-  .ruby-lsp \
+   .ruby-lsp \
+   log \
    vendor/bundle/ruby/3.*/cache
 find . -iname "*~undo-tree~" -delete
 popd
@@ -54,7 +56,8 @@ rm -rf \
    README.md \
    test \
    tmp \
-  .ruby-lsp \
+   .ruby-lsp \
+   log \
    vendor/bundle/ruby/3.*/cache
 find . -iname "*~undo-tree~" -delete
 popd

--- a/bin/ia_to_s3_migrator
+++ b/bin/ia_to_s3_migrator
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+# Usage: bundle exec bin/ia_to_s3_migrator
+
+require 'ruby-progressbar'
+require_relative '../lib/space_stone'
+
+puts '== Tail log/ia_to_s3_migrator.log for logs =='
+
+iaids = File.read('tmp/iaids.txt').split("\n")
+logger = Logger.new('log/ia_to_s3_migrator.log')
+progressbar = ProgressBar.create(total: iaids.size, format: '%a %e %P% Processed: %c from %C')
+s3_bucket = SpaceStone::S3Service.bucket
+
+iaids.each do |iaid|
+  # WARN: This dumbly checks for any downloads; if some files have been uploaded
+  # but some haven't, it will skip uploading all of them
+  if s3_bucket.objects(prefix: "#{iaid}/downloads").any?
+    logger.warn("== #{iaid} == Files have already been uploaded to S3, skipping")
+  else
+    logger.info(" == #{iaid} == Downloading files...")
+    process_ia_id(iaid, '/store/tmp/fast-tmp')
+  end
+  progressbar.increment
+end

--- a/bin/ia_to_s3_migrator
+++ b/bin/ia_to_s3_migrator
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Usage: bundle exec bin/ia_to_s3_migrator
+# Usage: STAGE_ENV=production docker compose run web 'bundle exec bin/ia_to_s3_migrator'
 
 require 'ruby-progressbar'
 require_relative '../lib/space_stone'

--- a/bin/ia_to_s3_migrator
+++ b/bin/ia_to_s3_migrator
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Usage: STAGE_ENV=production docker compose run web 'bundle exec bin/ia_to_s3_migrator'
+# Usage: bin/migrate_iaids
 
 require 'ruby-progressbar'
 require_relative '../lib/space_stone'

--- a/bin/ia_to_s3_migrator
+++ b/bin/ia_to_s3_migrator
@@ -18,7 +18,7 @@ iaids.each do |iaid|
   if s3_bucket.objects(prefix: "#{iaid}/downloads").any?
     logger.warn("== #{iaid} == Files have already been uploaded to S3, skipping")
   else
-    logger.info(" == #{iaid} == Downloading files...")
+    logger.info("== #{iaid} == Downloading files...")
     process_ia_id(iaid, '/store/tmp/fast-tmp')
   end
   progressbar.increment

--- a/bin/migrate_iaids
+++ b/bin/migrate_iaids
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-STAGE_ENV=production docker compose run web 'bundle exec bin/ia_to_s3_migrator'
+STAGE_ENV=production docker compose run --volume /store/tmp/fast-tmp:/store/tmp/fast-tmp web 'bundle exec bin/ia_to_s3_migrator'

--- a/bin/migrate_iaids
+++ b/bin/migrate_iaids
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+STAGE_ENV=production docker compose run web 'bundle exec bin/ia_to_s3_migrator'

--- a/bin/migrate_iaids
+++ b/bin/migrate_iaids
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -e
 
-STAGE_ENV=production docker compose run --volume /store/tmp/fast-tmp:/store/tmp/fast-tmp web 'bundle exec bin/ia_to_s3_migrator'
+STAGE_ENV=production docker compose run \
+  --rm \
+  --remove-orphans \
+  --volume /store/tmp/fast-tmp:/store/tmp/fast-tmp \
+  web \
+  'bundle exec bin/ia_to_s3_migrator'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ services:
       - .:/var/task:delegated
       - /var/run/docker.sock:/var/run/docker.sock
     command: "sam local start-api --host '0.0.0.0' --port 3030 --docker-volume-basedir ${PWD}"
-    entrypoint: /bin/bash
+    entrypoint: /bin/bash -c
     ports:
       - 3030:3030

--- a/lib/space_stone/sqs_service.rb
+++ b/lib/space_stone/sqs_service.rb
@@ -6,7 +6,11 @@ module SpaceStone
   # Service object to add messages to either sqs queue
   module SqsService
     def client
-      @client ||= Aws::SQS::Client.new(region: 'us-east-2')
+      @client ||= if ENV.fetch('AWS_S3_ACCESS_KEY_ID', nil)
+                    Aws::SQS::Client.new(region: 'us-east-2', credentials: Aws::Credentials.new(ENV.fetch('AWS_S3_ACCESS_KEY_ID'), ENV.fetch('AWS_S3_SECRET_ACCESS_KEY')))
+                  else
+                    Aws::SQS::Client.new(region: 'us-east-2')
+                  end
     end
 
     def ocr_queue_url


### PR DESCRIPTION
Ref:
- https://github.com/scientist-softserv/nnp/issues/316

Add a script that allows downloading, extracting, and uploading files to S3 on the local machine. It then triggers the next preprocess steps (OCR and thumbnail), which still happen in Lambdas.
This step usually happens in a Lamba, but if the Zip file is large enough, it can timeout. This script is intended to be run on the production server. 

Steps to use:

1. Add list of IAIDs that need to be preprocessed to `tmp/iaids.txt` 
2. Run `bin/migrate_iaids` 
3. Tail `log/ia_to_s3_migrator.log` to watch the progress 
4. Go look in the S3 bucket to ensure the files show up as expected 